### PR TITLE
Removes recursive call and minor fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ main(int argc, char** argv)
 In the `Flotsam.toml` "dependencies" section, add the following line:
 
 ```
-"github.com/briandowns/libspinner" = "0.2.2"
+"github.com/briandowns/libspinner" = "0.2.1"
 ```
 
 Now run `flotsam update`.  Flotsam parses the Flotsam.toml file, clones, checks out the given branch or tag, performs a build of the dependency, and makes it available for linking and execution.

--- a/dependency.c
+++ b/dependency.c
@@ -95,7 +95,7 @@ clone(const char* dep, const char* ver)
     // check if the directory already exists and if so, return;
     struct stat s = { 0 };
     if (stat(path, &s) == 0 && S_ISDIR(s.st_mode)) {
-        return dependency_update(dep, ver);
+        return 0;
     }
 
     git_repository* repo = NULL;

--- a/main.c
+++ b/main.c
@@ -195,8 +195,7 @@ strip_chars(char* s, const char* sc)
 int
 main(int argc, char** argv)
 {
-    int c;
-    if (argc < 1) {
+    if (argc < 2) {
         printf(USAGE, STR(bin_name));
         return 1;
     }


### PR DESCRIPTION
The check for an existing directory in the `clone` function makes a call to `dependency_update` if `true`.  Then, `clone` was being called from `dependency_update` again.

If I run `flotsam update` for a dependency that is already cached, these recursive calls appeared to happen until eventually SEG FAULTing.

I'm not quite sure what the desired behavior is to be if the repo is already cloned down - so I take no offense if you want to close this PR and tackle things in a different way 👍 .

* Also uses the latest `spinner` tag in the README example.
* Checks for at least 2 args since `arg[0]` is the program name.
* Removes an unused `int` at the top of `func main`.

AWESOME tool!